### PR TITLE
[contributing] Add a contributor-s guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,72 @@
+# Contributor's Guide
+
+## Communication
+
+- Respect each other. No form of discrimination or harassment will be tolerated.
+- Using inclusive terminology. Examples include:
+    - Use a “main” branch instead of a “master” branch.
+    - Use “blocklist” and “allowlist” instead of “blacklist” and “whitelist”.
+    - Use “primary” and “secondary” instead of “master” and “slave”.
+- Use [GitHub Issues](https://github.com/playtron-os/playtron-os-scripts/issues) to report bugs, security issues, or to open new feature requests.
+
+# Contributing
+
+There are three main ways to contribute:
+
+- Testing.
+    - The simplest way you can help contribute is to test out our project. Have new ideas or ran into issues? Open up a GitHub Issue with details to let us know.
+- Documentation.
+    - Help add new [documentation](https://github.com/playtron-os/playtron-os-scripts/issues?q=is%3Aopen+is%3Aissue+label%3Adocumentation) or reorganize existing documentation.
+- Code.
+    - Contribute new [features](https://github.com/playtron-os/playtron-os-scripts/issues?q=is%3Aopen+is%3Aissue+label%3Aenhancement) and [bug fixes](https://github.com/playtron-os/playtron-os-scripts/issues?q=is%3Aopen+is%3Aissue+label%3Abug).
+
+Look for GitHub Issues that have the label “[good first issue](https://github.com/playtron-os/playtron-os-scripts/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)” for simpler GitHub Issues to get started with.
+
+# Pull Request Workflow
+
+A pull request (PR) is required for any code to be merged into the project.
+
+- Create a PR with detailed information about what the purpose is.
+- Respond to feedback of the PR in a reasonable amount of time. Otherwise, it may be closed.
+- Before merging, the pull request must meet these requirements:
+    - Formatting is consistent with existing code.
+    - Passes all GitHub Actions CI tests.
+    - Approved by at least one Playtron employee.
+
+By submitting code to our project, you agree to the terms of the Developer's Certificate of Origin 1.1 agreement.
+
+```
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```
+
+# Style Guide
+
+- Prefer blank spaces over tabs. Indents should be 4 blank spaces.
+- Keep lines below 120 characters.
+- Prefer code that is simple to read.
+- For complex logic, add comments to explain the code.
+- Use meaningful and descriptive variable names.


### PR DESCRIPTION
This contributor's guide is based on the same one used by Playtron OS. Links have been updated to point to this new repository.

https://github.com/playtron-os/playtron-os/pull/48