### PR TITLE
Resize fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ Swap creation:
 
 ## License
 
-[Apache License Version 2.0](LICENSE).
+[GNU General Public License v3.0](LICENSE).


### PR DESCRIPTION
Creating swap can accidentally fill up a storage device. We now check to see how much storage is available first.