### PR TITLE
OST-227 add factory reset script

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ Swap creation:
 - ./usr/bin/create-swap.sh
     - A script to create swap if the RAM size is less than 32 GB.
 
+Factory reset:
+
+- ./usr/bin/playtron-factory-reset
+    - A script to factory reset the system
+- ./usr/share/polkit-1/rules.d/50-one.playtron.factory-reset.rules
+    - A PolicyKit rule to allow the user to run the factory reset script as root
+
 Configuration:
 
 - ./etc/gai.conf

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ Configuration:
 - ./usr/share/polkit-1/rules.d/50-one.playtron.rpmostree1.rules
     - Allow running OS upgrades without a password
 
+Device tweaks:
+
+- ./usr/lib/udev/rules.d/50-lenovo-legion-controller.rules
+    - Fixes controller on Legion Go
+
+
 ## License
 
 [GNU General Public License v3.0](LICENSE).

--- a/etc/sudoers.d/playtron
+++ b/etc/sudoers.d/playtron
@@ -1,0 +1,1 @@
+playtron ALL=(ALL) NOPASSWD: /usr/bin/playtron-factory-reset

--- a/etc/sudoers.d/playtron
+++ b/etc/sudoers.d/playtron
@@ -1,1 +1,0 @@
-playtron ALL=(ALL) NOPASSWD: /usr/bin/playtron-factory-reset

--- a/usr/bin/playtron-factory-reset
+++ b/usr/bin/playtron-factory-reset
@@ -35,8 +35,6 @@ reset_etc systemd
 reset_etc lightdm
 reset_etc ssh
 reset_etc xdg
-reset_etc sudoers.d
-rsync -aHX /usr/etc/sudoers /etc/sudoers
 rsync -aHX /usr/etc/gai.conf /etc/gai.conf
 
 # reset playtron password

--- a/usr/bin/playtron-factory-reset
+++ b/usr/bin/playtron-factory-reset
@@ -1,0 +1,61 @@
+#! /bin/bash
+
+if [ $EUID -ne 0 ]; then
+        echo "$(basename $0) must be run as root"
+        exit 1
+fi
+
+if [ "$1" == "--preserve-user-files" ]; then
+	PRESERVE_HOME=1
+fi
+
+shopt -s extglob
+
+function reset_etc {
+	dir=$1
+	if [ -z "$dir" ]; then
+		return 1
+	fi
+
+	rm -rf /etc/$dir/{,.}*
+
+	if [ -n "$(ls -A /usr/etc/$dir)" ]; then
+		# there are files to copy
+		rsync -aHX /usr/etc/$dir/* /etc/$dir
+	fi
+}
+
+# clear all package changes
+rpm-ostree reset &> /dev/null
+
+# TODO: reset all of /etc
+# reset some key files in /etc
+reset_etc NetworkManager
+reset_etc systemd
+reset_etc lightdm
+reset_etc ssh
+reset_etc xdg
+reset_etc sudoers.d
+rsync -aHX /usr/etc/sudoers /etc/sudoers
+rsync -aHX /usr/etc/gai.conf /etc/gai.conf
+
+# reset playtron password
+echo 'playtron:playtron' | chpasswd
+
+# clean /var, keep "home"
+rm -rf /var/!("home")
+rm -rf /var/.*
+
+# delete swap file and any added users or files in /home, keep "playtron"
+swapoff -a
+rm -rf /home/!("playtron")
+rm -rf /home/.*
+
+if [ -z "$PRESERVE_HOME" ]; then
+	# delete home directory contents
+	rm -rf /home/playtron/{,.}*
+fi
+
+echo "Factory reset complete, rebooting..."
+
+systemctl reboot

--- a/usr/lib/systemd/system-preset/50-playtron.preset
+++ b/usr/lib/systemd/system-preset/50-playtron.preset
@@ -1,3 +1,4 @@
 enable lightdm.service
 enable create-swap.service
 enable resize-root-file-system.service
+disable firewalld.service

--- a/usr/share/polkit-1/rules.d/50-one.playtron.factory-reset.rules
+++ b/usr/share/polkit-1/rules.d/50-one.playtron.factory-reset.rules
@@ -1,0 +1,5 @@
+polkit.addRule(function(action, subject) {
+    if (action.id == "org.freedesktop.policykit.exec" && subject.isInGroup("wheel") && action.lookup("program") == "/usr/bin/playtron-factory-reset") {
+        return polkit.Result.YES;
+    }
+});


### PR DESCRIPTION
 - added `playtron-factory-reset` script
 - added permissions to execute `playtron-factory-reset` without a sudo password
 - disabled firewalld service in preset file to avoid factory reset re-enabling it

Testing:
 - tested full reset on a PlaytronOS installation with `playtron-factory-reset`, worked as expected
 - tested partial reset on a PlaytronOS installation with `playtron-factory-reset --preserve-user-files`, worked as expected


Sibling PR: https://github.com/playtron-os/playtron-os/pull/76